### PR TITLE
Small fixes

### DIFF
--- a/src/main/java/dev/skidfuscator/gradle/SkidfuscatorPlugin.java
+++ b/src/main/java/dev/skidfuscator/gradle/SkidfuscatorPlugin.java
@@ -31,9 +31,9 @@ public class SkidfuscatorPlugin implements Plugin<Project> {
         SkidfuscatorExtension extension = project.getExtensions().create("skidfuscator", SkidfuscatorExtension.class, transformerContainer);
 
         project.afterEvaluate(p -> {
-            Task jarTask = p.getTasks().findByName("jar");
-            Task shadowJarTask = p.getTasks().findByName("shadowJar");
-            Task finalTask = (shadowJarTask != null) ? shadowJarTask : jarTask;
+            Jar jarTask = p.getTasks().withType(Jar.class).findByName("jar");
+            Jar shadowJarTask = p.getTasks().withType(Jar.class).findByName("shadowJar");
+            Jar finalTask = (shadowJarTask != null) ? shadowJarTask : jarTask;
 
             if (finalTask == null) {
                 project.getLogger().lifecycle("No jar or shadowJar task found. Skidfuscator will not run automatically.");
@@ -116,12 +116,7 @@ public class SkidfuscatorPlugin implements Plugin<Project> {
                     }
                 }
 
-                File outputJar;
-                if (shadowJarTask != null) {
-                    outputJar = new File(p.getBuildDir(), "libs/" + p.getName() + "-" + p.getVersion() + "-all.jar");
-                } else {
-                    outputJar = new File(p.getBuildDir(), "libs/" + p.getName() + "-" + p.getVersion() + ".jar");
-                }
+                File outputJar = finalTask.getArchiveFile().get().getAsFile();
 
                 if (!outputJar.exists()) {
                     project.getLogger().lifecycle("Output jar not found at " + outputJar.getAbsolutePath() + ", cannot run Skidfuscator.");

--- a/src/main/java/dev/skidfuscator/gradle/SkidfuscatorPlugin.java
+++ b/src/main/java/dev/skidfuscator/gradle/SkidfuscatorPlugin.java
@@ -104,7 +104,7 @@ public class SkidfuscatorPlugin implements Plugin<Project> {
                     skidJar.getParentFile().mkdirs();
                 }
                 // If version changed or jar not present, re-download
-                if (!"dev".equalsIgnoreCase(resolvedVersion) && resolvedVersion.equals(currentVersion) || !skidJar.exists()) {
+                if (!"dev".equalsIgnoreCase(resolvedVersion) && !resolvedVersion.equals(currentVersion) || !skidJar.exists()) {
                     project.getLogger().warn("Could not find Skidfuscator jar at " + skidJar.getAbsolutePath() + ", downloading...");
                     project.getLogger().lifecycle("Downloading Skidfuscator " + resolvedVersion + "...");
                     try {


### PR DESCRIPTION
- Detect the actual file used for jar/shadowJar output, rather than requiring it to be in a specific directory with a specific file name.
- Fixed version change detection. Previously, the skidfuscator jar was redownloaded whenever the desired version matched the .version file.