### PR TITLE
Support `exclude` config

### DIFF
--- a/src/main/java/dev/skidfuscator/gradle/SkidfuscatorExtension.java
+++ b/src/main/java/dev/skidfuscator/gradle/SkidfuscatorExtension.java
@@ -11,6 +11,7 @@ import java.util.List;
 @Setter
 public class SkidfuscatorExtension {
     private List<String> exempt = new ArrayList<>();
+    private List<String> exclude = new ArrayList<>();
     private List<String> libs = new ArrayList<>();
 
     // Dynamic transformers container

--- a/src/main/java/dev/skidfuscator/gradle/SkidfuscatorPlugin.java
+++ b/src/main/java/dev/skidfuscator/gradle/SkidfuscatorPlugin.java
@@ -272,6 +272,7 @@ public class SkidfuscatorPlugin implements Plugin<Project> {
     private Config buildConfig(SkidfuscatorExtension ext) {
         Map<String, Object> rootMap = new HashMap<>();
         rootMap.put("exempt", ext.getExempt());
+        rootMap.put("exclude", ext.getExclude());
         rootMap.put("libraries", ext.getLibs());
 
         // Dynamically add transformers


### PR DESCRIPTION
Simple addition. just support `exclude` config from https://github.com/skidfuscatordev/skidfuscator-java-obfuscator/commit/18d4aae67de3bea78e704c7f852b1af311d8a836

example:
```gradle
skidfuscator {
    ....
    exclude << "@class com.foo.bar.a"
    exclude << "!@class com.foo.bar.**"
    exclude << """
       @class com.foo.bar.b {
           @method run()
       }
    """
}
```